### PR TITLE
Allow http / https config settings

### DIFF
--- a/src/main/scala/kamon/zipkin/Zipkin.scala
+++ b/src/main/scala/kamon/zipkin/Zipkin.scala
@@ -133,11 +133,13 @@ class ZipkinReporter extends SpanReporter {
   }
 
   private def buildReporter() = {
-    val zipkinHost = Kamon.config().getString(HostConfigKey)
+    var zipkinHost = Kamon.config().getString(HostConfigKey)
     val zipkinPort = Kamon.config().getInt(PortConfigKey)
-
+    if (!zipkinHost.contains("://")) {
+      zipkinHost = "http://"
+    }
     AsyncReporter.create(
-      OkHttpSender.create(s"http://$zipkinHost:$zipkinPort/api/v2/spans")
+      OkHttpSender.create(s"$zipkinHost:$zipkinPort/api/v2/spans")
     )
   }
 

--- a/src/main/scala/kamon/zipkin/Zipkin.scala
+++ b/src/main/scala/kamon/zipkin/Zipkin.scala
@@ -136,7 +136,7 @@ class ZipkinReporter extends SpanReporter {
     var zipkinHost = Kamon.config().getString(HostConfigKey)
     val zipkinPort = Kamon.config().getInt(PortConfigKey)
     if (!zipkinHost.contains("://")) {
-      zipkinHost = "http://"
+      zipkinHost = s"http://$zipkinHost"
     }
     AsyncReporter.create(
       OkHttpSender.create(s"$zipkinHost:$zipkinPort/api/v2/spans")


### PR DESCRIPTION
Instead of hard-coding it to connect to http this changes allows to configure the protocol in a backward-compatible way.