### PR TITLE
Kamon-Zipkin update to not hard code http

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Supported releases and dependencies are shown below.
 
 | kamon-zipkin | status | jdk  | scala            |
 |:------------:|:------:|:----:|------------------|
-|  1.0.0   |   stable   | 1.8+ | 2.10, 2.11, 2.12 |
+|  1.1.0   |   stable   | 1.8+ | 2.10, 2.11, 2.12 |
 
 
 To get started with SBT, simply add the following to your `build.sbt` file:
 
 ```scala
-libraryDependencies += "io.kamon" %% "kamon-zipkin" % "1.0.0"
+libraryDependencies += "io.kamon" %% "kamon-zipkin" % "1.1.0"
 ```
 
 You can find more info on [kamon.io](http://kamon.io) and in our [Monitoring Akka Quickstart Recipe][1]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 lazy val root: Project = project.in(file(".")).dependsOn(latestSbtUmbrella)
-lazy val latestSbtUmbrella = uri("git://github.com/kamon-io/kamon-sbt-umbrella.git")
+lazy val latestSbtUmbrella = RootProject(uri("git://github.com/kamon-io/kamon-sbt-umbrella.git"))

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,5 @@
 kamon {
   zipkin {
-    host = "localhost"
-    port = 9411
+    url = "http://localhost:9411"
   }
 }

--- a/src/main/scala/kamon/zipkin/Zipkin.scala
+++ b/src/main/scala/kamon/zipkin/Zipkin.scala
@@ -133,11 +133,9 @@ class ZipkinReporter extends SpanReporter {
   }
 
   private def buildReporter() = {
-    val zipkinHost = Kamon.config().getString(HostConfigKey)
-    val zipkinPort = Kamon.config().getInt(PortConfigKey)
-
+    val zipkinBaseUrl = Kamon.config().getString(UrlConfigKey)
     AsyncReporter.create(
-      OkHttpSender.create(s"http://$zipkinHost:$zipkinPort/api/v2/spans")
+      OkHttpSender.create(s"$zipkinBaseUrl/api/v2/spans")
     )
   }
 
@@ -151,8 +149,7 @@ class ZipkinReporter extends SpanReporter {
 }
 
 object ZipkinReporter {
-  private val HostConfigKey = "kamon.zipkin.host"
-  private val PortConfigKey = "kamon.zipkin.port"
+  private val UrlConfigKey = "kamon.zipkin.url"
   private val SpanKindTag = "span.kind"
   private val SpanKindServer = "server"
   private val SpanKindClient = "client"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
This RP includes the updates below:
- allows to configure the protocol in a backward-compatible way Instead of hard-coding to http;
- solved the dependency issue of the latest kamon-sbt-umbrella
