### PR TITLE
Add posibility to override zipkin server url

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,7 +12,7 @@ kamon.zipkin {
   # Decides whether to use HTTP or HTTPS when connecting to Zipkin
   protocol = "http"
 
-  full-server-url = ${kamon.zipkin.protocol}"://"${kamon.zipkin.host}":"${kamon.zipkin.port}"/api/v2/spans"
+  url = ${kamon.zipkin.protocol}"://"${kamon.zipkin.host}":"${kamon.zipkin.port}"/api/v2/spans"
 }
 
 kamon.modules {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,6 +11,8 @@ kamon.zipkin {
 
   # Decides whether to use HTTP or HTTPS when connecting to Zipkin
   protocol = "http"
+
+  full-server-url = ${kamon.zipkin.protocol}"://"${kamon.zipkin.host}":"${kamon.zipkin.port}"/api/v2/spans"
 }
 
 kamon.modules {

--- a/src/main/scala/kamon/zipkin/ZipkinReporter.scala
+++ b/src/main/scala/kamon/zipkin/ZipkinReporter.scala
@@ -134,10 +134,7 @@ class ZipkinReporter(configPath: String) extends SpanReporter {
 
   private def buildReporter(config: Config) = {
     val zipkinConfig = config.getConfig(configPath)
-    val zipkinHost = zipkinConfig.getString("host")
-    val zipkinPort = zipkinConfig.getInt("port")
-    val zipkinProtocol = zipkinConfig.getString("protocol").toLowerCase
-    val fullServerUrl = s"$zipkinProtocol://$zipkinHost:$zipkinPort/api/v2/spans"
+    val fullServerUrl = zipkinConfig.getString("full-server-url")
 
     AsyncReporter.create(OkHttpSender.create(fullServerUrl))
   }

--- a/src/main/scala/kamon/zipkin/ZipkinReporter.scala
+++ b/src/main/scala/kamon/zipkin/ZipkinReporter.scala
@@ -134,7 +134,7 @@ class ZipkinReporter(configPath: String) extends SpanReporter {
 
   private def buildReporter(config: Config) = {
     val zipkinConfig = config.getConfig(configPath)
-    val fullServerUrl = zipkinConfig.getString("full-server-url")
+    val fullServerUrl = zipkinConfig.getString("url")
 
     AsyncReporter.create(OkHttpSender.create(fullServerUrl))
   }


### PR DESCRIPTION
I have a use case, where zipkin servier url is not in the form of `$zipkinProtocol://$zipkinHost:$zipkinPort/api/v2/spans`, so I'd like to override it.

I suggest url concatenation in config, so when someone has specific url (like additional query params or something) it can be overridden.