### PR TITLE
Ignoring error=false tag in zipkin traces

### DIFF
--- a/src/main/scala/kamon/zipkin/ZipkinReporter.scala
+++ b/src/main/scala/kamon/zipkin/ZipkinReporter.scala
@@ -102,7 +102,9 @@ class ZipkinReporter(configPath: String) extends SpanReporter {
   }
 
   private def addTags(tags: TagSet, builder: ZipkinSpan.Builder): Unit =
-    tags.iterator(_.toString).foreach(pair => builder.putTag(pair.key, pair.value))
+    tags.iterator(_.toString)
+      .filterNot(pair => pair.key == Span.TagKeys.Error && pair.value == "false") // zipkin considers any error tag as failed request
+      .foreach(pair => builder.putTag(pair.key, pair.value))
 
   private def getStringTag(span: Span.Finished, tagName: String): String =
     span.tags.get(option(tagName)).orElse(span.metricTags.get(option(tagName))).orNull


### PR DESCRIPTION
Kamon by default adds tag `error` to the Span, which is of type `boolean`. When it gets converted to ZipkinSpan it gets translated to `String`. 

In the result successful requests are sent with `"tags":{"error":"false"}` which is considered by `zipkin` as failed request (and presented so).

This PR makes filtering of tags during conversion to ZipkinSpan.