### PR TITLE
:= fixes issue #14 and upgrades Scala and the dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
 
 libraryDependencies ++= Seq(
   "io.kamon" %% "kamon-core" % "2.0.5",
-  "io.zipkin.reporter2" % "zipkin-reporter" % "2.7.14",
-  "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.7.14",
+  "io.zipkin.reporter2" % "zipkin-reporter" % "2.7.15",
+  "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.7.15",
   scalatest % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.11"
 resolvers += Resolver.mavenLocal
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
 
 libraryDependencies ++= Seq(
-  "io.kamon" %% "kamon-core" % "2.0.0",
+  "io.kamon" %% "kamon-core" % "2.0.5",
   "io.zipkin.reporter2" % "zipkin-reporter" % "2.7.14",
   "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.7.14",
   scalatest % "test"

--- a/src/main/scala/kamon/zipkin/ZipkinReporter.scala
+++ b/src/main/scala/kamon/zipkin/ZipkinReporter.scala
@@ -57,7 +57,7 @@ class ZipkinReporter(configPath: String) extends SpanReporter {
     spans.map(convertSpan).foreach(_reporter.report)
 
   private[zipkin] def convertSpan(kamonSpan: Span.Finished): ZipkinSpan = {
-    val duration = Math.floorDiv(Clock.nanosBetween(kamonSpan.from, kamonSpan.to), 1000)
+    val duration = Math.floorDiv(Clock.nanosBetween(kamonSpan.from, kamonSpan.to), 1000L)
     // Zipkin uses null to identify no identifier
     val parentId: String = if (kamonSpan.parentId.isEmpty) null else kamonSpan.parentId.string
     val builder = ZipkinSpan.newBuilder()


### PR DESCRIPTION
This PR includes:

* Solves issue #14 :
The second parameterpassed to  `Math.floorDiv()` (value `1000`)  needs to be forced to `Long`. Otherwise, the Scala compiler doesn't  generate the correct invocation in the bytecode generated.

* Upgrades to Scala `2.12.11` and upgrade the minor version of the depedencies.